### PR TITLE
Bump MDB Server to 8.2.3 for Search. Fix Vector test query  bug

### DIFF
--- a/MEKO-opsmanager/scripts/search_setup.sh
+++ b/MEKO-opsmanager/scripts/search_setup.sh
@@ -271,7 +271,7 @@ EOF
 )
 
 kubectl exec --context "${K8S_CTX}" -n "${MDB_NS}" mongodb-tools-pod -- /bin/bash -eu -c "$(cat <<EOF
-echo '${mdb_script}' > /tmp/mdb_vector_script.js
+echo '${mdb_vector_script}' > /tmp/mdb_vector_script.js
 mongosh --quiet "${MDB_CONNECTION_STRING}" < /tmp/mdb_vector_script.js
 EOF
 )"

--- a/MEKO-opsmanager/scripts/search_setup.sh
+++ b/MEKO-opsmanager/scripts/search_setup.sh
@@ -271,7 +271,7 @@ EOF
 )
 
 kubectl exec --context "${K8S_CTX}" -n "${MDB_NS}" mongodb-tools-pod -- /bin/bash -eu -c "$(cat <<EOF
-echo '${mdb_vector_script}' > /tmp/mdb_vector_script.js
+echo '${mdb_script}' > /tmp/mdb_vector_script.js
 mongosh --quiet "${MDB_CONNECTION_STRING}" < /tmp/mdb_vector_script.js
 EOF
 )"

--- a/MEKO-opsmanager/search_mdb.yaml
+++ b/MEKO-opsmanager/search_mdb.yaml
@@ -3,8 +3,8 @@ kind: MongoDB
 metadata:
   name: mdb-rs
 spec:
-  members: 3
-  version: 8.2.3-ent
+  members: 1
+  version: 8.0.10-ent
   type: ReplicaSet
   opsManager:
     configMapRef:
@@ -16,19 +16,6 @@ spec:
       ignoreUnknownUsers: true
       modes:
       - SCRAM
-      requireClientTLSAuthentication: false
-    certsSecretPrefix: "mdb"
-    tls:
-      ca: "my-ca"
-  connectivity:
-    replicaSetHorizons:
-      - "nodeport": "mdb-rs-0.localhost:32017"
-      - "nodeport": "mdb-rs-1.localhost:32018"
-      - "nodeport": "mdb-rs-2.localhost:32019"
-  additionalMongodConfig:
-    net:
-      ssl:
-        mode: "allowSSL"
   agent:
     logLevel: DEBUG
   statefulSet:

--- a/MEKO-opsmanager/search_mdb.yaml
+++ b/MEKO-opsmanager/search_mdb.yaml
@@ -3,8 +3,8 @@ kind: MongoDB
 metadata:
   name: mdb-rs
 spec:
-  members: 1
-  version: 8.0.10-ent
+  members: 3
+  version: 8.2.3-ent
   type: ReplicaSet
   opsManager:
     configMapRef:
@@ -16,6 +16,19 @@ spec:
       ignoreUnknownUsers: true
       modes:
       - SCRAM
+      requireClientTLSAuthentication: false
+    certsSecretPrefix: "mdb"
+    tls:
+      ca: "my-ca"
+  connectivity:
+    replicaSetHorizons:
+      - "nodeport": "mdb-rs-0.localhost:32017"
+      - "nodeport": "mdb-rs-1.localhost:32018"
+      - "nodeport": "mdb-rs-2.localhost:32019"
+  additionalMongodConfig:
+    net:
+      ssl:
+        mode: "allowSSL"
   agent:
     logLevel: DEBUG
   statefulSet:

--- a/MEKO-opsmanager/search_mdb.yaml
+++ b/MEKO-opsmanager/search_mdb.yaml
@@ -4,7 +4,7 @@ metadata:
   name: mdb-rs
 spec:
   members: 1
-  version: 8.0.10-ent
+  version: 8.2.3-ent
   type: ReplicaSet
   opsManager:
     configMapRef:


### PR DESCRIPTION
Bump MDB Server to from 8.0.10 -> 8.2.3 for Search.
Fix the Vector Query test, where the test was just executing again previous Search Query test

Attach testing output
-> MDB Server running on 8.2.3
-> Vector test query output
<img width="1095" height="681" alt="mdb_8_2_3" src="https://github.com/user-attachments/assets/f1921ec7-a4c7-45b1-ba95-352794e16041" />
<img width="1119" height="599" alt="verctor_query" src="https://github.com/user-attachments/assets/4eb9eb68-3096-4398-aa8e-e9d9bd8f8427" />

